### PR TITLE
Download Calamares from bookworm-backports

### DIFF
--- a/build-steps.d/2100_create-debian-packages
+++ b/build-steps.d/2100_create-debian-packages
@@ -154,6 +154,23 @@ download_packages_from_debian_sid() {
    build_run_function get_newer_packages_from_third_party_repositories "$@"
 }
 
+download_packages_from_debian_bookworm_backports() {
+   available_architectures_for_download_only_list="all"
+   dist_build_special_packages_chroot_script="$dist_source_help_steps_folder/repo_download_chroot_script"
+   repo_signing_key="none"
+   repo_sources_list="$dist_build_sources_list_debian_bookworm_backports"
+   temp_newer_packages="$binary_build_folder_dist/temp_packages_debian_bookworm_backports"
+   export download_source_package="false"
+
+   newer_package_list=""
+   
+   if [ "$dist_build_iso" = "true" ]; then
+      newer_package_list="calamares"
+   fi
+
+   build_run_function get_newer_packages_from_third_party_repositories "$@";
+}
+
 get_newer_packages_from_third_party_repositories() {
    true "${cyan}$BASH_SOURCE INFO: Downloading newer packages from third-party repository... ${reset}"
 
@@ -409,6 +426,7 @@ create-debian-packages() {
 
    #build_run_function download_virtualbox_packages_virtualbox_org "$@"
    #build_run_function download_packages_from_debian_sid "$@"
+   build_run_function download_packages_from_debian_bookworm_backports "$@"
 
    ## https://www.whonix.org/wiki/Dev/Tor
    ## https://forums.whonix.org/t/tor-integration-in-whonix/10593/57

--- a/build_sources/debian_bookworm_backports_current_clearnet.list
+++ b/build_sources/debian_bookworm_backports_current_clearnet.list
@@ -1,0 +1,14 @@
+## Copyright (C) 2012 - 2023 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
+## See the file COPYING for copying conditions.
+
+## Using specific codenames (for example: "bookworm") rather than generic code
+## names (for example: "stable") because grml-debootstrap did not support
+## generic code names for --release. See also:
+## github.com/grml/grml-debootstrap/issues/37
+
+## Using contrib, because it contains virtualbox-guest-x11.
+
+## Added deb-src so source package can also be downloaded.
+
+deb http://HTTPS///deb.debian.org/debian bookworm-backports main contrib non-free non-free-firmware
+deb-src http://HTTPS///deb.debian.org/debian bookworm-backports main contrib non-free non-free-firmware

--- a/build_sources/debian_stable_current_clearnet.list
+++ b/build_sources/debian_stable_current_clearnet.list
@@ -16,6 +16,8 @@ deb-src http://HTTPS///deb.debian.org/debian-security bookworm-security main con
 deb http://HTTPS///deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
 deb-src http://HTTPS///deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
 
+# TODO: Can be out-commented for debian trixie, required for getting newer
+# debhelper in help-steps/pbuilder-chroot-script
 deb http://HTTPS///deb.debian.org/debian bookworm-backports main contrib non-free non-free-firmware
 deb-src http://HTTPS///deb.debian.org/debian bookworm-backports main contrib non-free non-free-firmware
 

--- a/buildconfig.d/25_apt_sources.conf
+++ b/buildconfig.d/25_apt_sources.conf
@@ -150,6 +150,14 @@ if [ "$dist_build_sources_list_debian_sid" = "" ]; then
    fi
 fi
 
+if [ "$dist_build_sources_list_debian_bookworm_backports" = "" ]; then
+   if [ "$dist_build_sources_clearnet_or_onion" = "clearnet" ]; then
+      dist_build_sources_list_debian_bookworm_backports="$source_code_folder_dist/build_sources/debian_bookworm_backports_current_clearnet.list"
+   else
+      dist_build_sources_list_debian_bookworm_backports="$source_code_folder_dist/build_sources/debian_bookworm_backports_current_onion.list"
+   fi
+fi
+
 if [ "$build_remote_repo_enable" = "true" ]; then
    DERIVATIVE_APT_REPOSITORY_OPTS="--enable --codename $dist_build_apt_stable_release"
    export DERIVATIVE_APT_REPOSITORY_OPTS


### PR DESCRIPTION
## Changes

This pull request downloads Calamares from bookworm-backports rather than from bookworm. This pulls in a significantly newer version of Calamares that contains support for disabling encryption on specific partitions. See https://github.com/Kicksecure/live-config-dist/pull/5 for more information.

NOTE: For installation to still work right after this, a new submodule for calamares-settings-debian MUST be added to `packages/kicksecure`! Source code suitable for this purpose can be obtained from https://github.com/ArrayBolt3/calamares-settings-debian (though I recommend cloning that repo, reviewing it, and then pushing it to a Kicksecure-specific location rather than using it directly - it contains a Unicode character fix and some Lintian tag overrides for genmkfile). Additionally, it will be necessary to merge the live-config-dist pull request linked above.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it