### PR TITLE
Add threat model and debugging comments for code reviewers

### DIFF
--- a/derivative-maker
+++ b/derivative-maker
@@ -3,6 +3,9 @@
 ## Copyright (C) 2012 - 2025 ENCRYPTED SUPPORT LLC <adrelanos@whonix.org>
 ## See the file COPYING for copying conditions.
 
+## Comments for reviewers:
+## Verbose logs (set -x) are preferred for build debugging.
+## Secret leak prevention in CI must be handled at the CI/environment level, not by disabling trace output.
 set -x
 set -e
 

--- a/help-steps/pre
+++ b/help-steps/pre
@@ -176,6 +176,8 @@ exit code $interactive_chroot_shell_bash_exit_code, cleanup and exit as requeste
 }
 
 exception_handler_retry() {
+   ## Comments for reviewers:
+   ## threat model: command line is considered trusted in derivative-maker.
    if [ ! "$dist_build_dispatch_before_retry" = "" ]; then
       $output_cmd "${cyan}${bold}INFO: dispatch before retry (--retry-before)...: $dist_build_dispatch_before_retry ${reset}"
       dist_build_dispatch_before_retry_exit_code="0"

--- a/help-steps/variables
+++ b/help-steps/variables
@@ -791,6 +791,8 @@ set_default_variable() {
 
   if [ -z "${!var_name:-}" ]; then
     #printf "%s\n" "INFO: Variable '$var_name' is already set? No. - Setting: $var_name='$var_content'"
+    ## Comments for reviewers:
+    ## threat model: command line is considered trusted in derivative-maker.
     eval "$var_name='$var_content'"
     return 0
   fi
@@ -913,6 +915,8 @@ fi
 
 ## {{{ buildconfig.d
 
+## Comments for reviewers:
+## threat model: files on the file system are considered trusted.
 [ -n "$dist_build_config_dirs" ] || dist_build_config_dirs="${source_code_folder_dist}/buildconfig.d /etc/buildconfig-dist.d ../buildconfig.d"
 
 dist_build_source_config_dir() {


### PR DESCRIPTION
## Summary
This PR adds clarifying comments throughout the codebase to document threat model assumptions and debugging practices for code reviewers.

## Key Changes
- **derivative-maker**: Added comments explaining that verbose logs (`set -x`) are preferred for build debugging, and that secret leak prevention should be handled at the CI/environment level rather than by disabling trace output
- **help-steps/variables**: Added threat model comment clarifying that command line arguments are considered trusted in derivative-maker
- **help-steps/variables**: Added threat model comment clarifying that files on the file system are considered trusted
- **help-steps/pre**: Added threat model comment clarifying that command line arguments are considered trusted in the `exception_handler_retry()` function

## Implementation Details
These are non-functional documentation comments added to critical sections of the build system to help reviewers understand the security assumptions and design decisions:
- The comments establish that the build system operates under a threat model where command-line inputs and filesystem sources are trusted
- The comments justify the use of verbose logging (`set -x`) for debugging purposes and clarify that secret protection is a CI/environment responsibility

https://claude.ai/code/session_01PYxHMF7ChedHCqqrmoqhAQ