### PR TITLE
Add documentation and enable signature verification for git submodules

### DIFF
--- a/derivative-update
+++ b/derivative-update
@@ -146,7 +146,7 @@ update_repo() {
     ## Caution.
     ## This command updates Git submodules to the commit recorded in the parent repository. (derivative-maker)
     ## It modifies the submodule's Git HEAD, potentially overriding local changes.
-    git -c merge.verifySignatures=true submodule update --init --recursive --jobs=200 --merge \
+    "${git_verify_command_wrapper[@]}" -c merge.verifySignatures=true submodule update --init --recursive --jobs=200 --merge \
       || abort_update \
         'Submodule update failed!' \
         "${dist_build_current_git_head}"
@@ -221,7 +221,7 @@ update_repo() {
       ## Caution.
       ## This command updates Git submodules to the commit recorded in the parent repository. (derivative-maker)
       ## It modifies the submodule's Git HEAD, potentially overriding local changes.
-      git -c merge.verifySignatures=true submodule update --init --recursive --jobs=200 --merge \
+      "${git_verify_command_wrapper[@]}" -c merge.verifySignatures=true submodule update --init --recursive --jobs=200 --merge \
         || abort_update \
           'Submodule update failed!' \
           "${dist_build_current_git_head}" "${branch_reset_commit}"

--- a/help-steps/git_sanity_test
+++ b/help-steps/git_sanity_test
@@ -206,6 +206,10 @@ git_sanity_test_main() {
    ## compromised, but if the repo is safe, this (in combination with the key
    ## import above) will do the initial verification, providing "trust on first
    ## use" (TOFU) security.
+   ##
+   ## TOFU threat model: Initial digital software verification must be done
+   ## manually for stronger-than-TOFU security. See:
+   ## https://www.kicksecure.com/wiki/Dev/Build_Documentation/images
    verify_ref "${dist_build_current_git_head}" 'commit'
 
    git_sanity_test_check_for_untagged_commits

--- a/help-steps/signing-key-create
+++ b/help-steps/signing-key-create
@@ -77,6 +77,7 @@ gpg_key_debugging() {
    sq cert lint --cert-email "$DEBEMAIL"
 }
 
+## Signify keys are used by 'dm-prepare-release' in package 'developer-meta-files'.
 signify_key_create() {
    mkdir --parents -- "$signify_folder"
    chmod --recursive -- og-rwx "$signify_folder"

--- a/help-steps/signing-key-test
+++ b/help-steps/signing-key-test
@@ -48,6 +48,7 @@ main() {
    safe-rm -- "$binary_build_folder_dist/test_sign_file"
    safe-rm -- "$binary_build_folder_dist/test_sign_file.asc"
 
+   ## Signify keys are used by 'dm-prepare-release' in package 'developer-meta-files'.
    ## TODO: stub
    test -d ~/.signify
 }

--- a/help-steps/sq-git-wrapper
+++ b/help-steps/sq-git-wrapper
@@ -3,9 +3,9 @@
 ## Copyright (C) 2026 - 2026 ENCRYPTED SUPPORT LLC <adrelanos@whonix.org>
 ## See the file COPYING for copying conditions.
 
-## NOTE: Unused!
-## TODO: Remove?
-## Replaced by 'sq-git'.
+## Used as 'gpg.openpgp.program' by 'git_verify_command_wrapper' (defined in
+## 'help-steps/variables') for submodule signature verification in
+## 'derivative-update'.
 
 #set -x
 set -o nounset

--- a/help-steps/variables
+++ b/help-steps/variables
@@ -213,6 +213,10 @@ fi
 if [ "$dist_build_redistributable" = "true" ]; then
    if [ "$CI" = "true" ]; then
       ## Compatible with git shallow clone.
+      ## By design. CI is untrusted. Compromised CI is out-of-scope and not
+      ## part of the threat model. Using 'HEAD' as the trust root is
+      ## acceptable because CI environments are not expected to provide
+      ## stronger guarantees than TOFU.
       [[ -v sq_git_trust_root ]] || sq_git_trust_root="HEAD"
    else
       ## Use "safer" 'sq-git log' root of trust ('--trust-root').
@@ -244,6 +248,11 @@ if [ "$dist_build_redistributable" = "true" ]; then
    fi
 else
    ## Compatible with git shallow clone.
+   ## Non-redistributable (personal) builds always use 'HEAD' as the trust
+   ## root. This is by design: personal builds are created by the developer
+   ## on their own machine from their own checkout, so the checkout is
+   ## already trusted. Full history-based trust root verification is only
+   ## required for redistributable builds.
    [[ -v sq_git_trust_root ]] || sq_git_trust_root="HEAD"
 
    ## Non-redistributable builds use '--tb open' by default.


### PR DESCRIPTION
## Summary
This PR improves documentation clarity around git trust models and enables cryptographic signature verification for git submodule updates in the derivative-update process.

## Key Changes

- **Submodule signature verification**: Updated `derivative-update` to use `git_verify_command_wrapper` for submodule updates, enabling signature verification via `merge.verifySignatures=true` configuration.

- **Trust model documentation**: Added comprehensive comments explaining the trust root strategy:
  - CI builds use 'HEAD' as trust root (acceptable for untrusted CI environments following TOFU model)
  - Non-redistributable builds use 'HEAD' as trust root (developer's own trusted checkout)
  - Redistributable builds use full history-based verification for stronger guarantees

- **TOFU security clarification**: Added reference to TOFU (Trust On First Use) threat model documentation in `git_sanity_test`, noting that manual verification is required for stronger-than-TOFU security.

- **sq-git-wrapper clarification**: Updated comments to document that `sq-git-wrapper` is actively used as `gpg.openpgp.program` for submodule signature verification, removing outdated "Unused/TODO" notes.

- **Signify key documentation**: Added comments clarifying that signify keys are used by `dm-prepare-release` in the `developer-meta-files` package.

## Implementation Details

The signature verification is now consistently applied across both redistributable and non-redistributable build paths in `derivative-update`, using the `git_verify_command_wrapper` array variable that configures the appropriate OpenPGP program for git operations.

https://claude.ai/code/session_018JRiKMycfRvtpzuK59NgwP