### PR TITLE
Add submodule verification to git sanity checks

### DIFF
--- a/derivative-update
+++ b/derivative-update
@@ -151,6 +151,8 @@ update_repo() {
         'Submodule update failed!' \
         "${dist_build_current_git_head}"
 
+    git_submodule_verify
+
   elif [ -n "${target_ref}" ]; then
     if ! verify_ref "${target_ref}" 'commit'; then
       abort_update 'Ref verification failed!'
@@ -225,6 +227,7 @@ update_repo() {
         || abort_update \
           'Submodule update failed!' \
           "${dist_build_current_git_head}" "${branch_reset_commit}"
+      git_submodule_verify
       verify_ref "${target_ref}" 'commit' \
         || abort_update \
           'Verification failed after submodule update!' \

--- a/help-steps/git_sanity_test
+++ b/help-steps/git_sanity_test
@@ -200,6 +200,35 @@ ${under}git reset --hard${eunder}
    true
 }
 
+git_submodule_verify() {
+   ## Submodule repositories intentionally do not include their own sq-git
+   ## policy file (openpgp-policy.toml). A single policy file in the parent
+   ## repository (derivative-maker) is used for all verification, keeping
+   ## signing policy centralized and avoiding duplication across repositories.
+
+   readarray -t submodule_path_list < <(
+      grep --fixed-strings 'path =' -- '.gitmodules' | awk -- '{ print $3 }'
+   )
+   local submodule_path_item submodule_head
+   for submodule_path_item in "${submodule_path_list[@]}"; do
+      if [ ! -d "${submodule_path_item}/.git" ]; then
+         true "INFO: Submodule '${submodule_path_item}' is not initialized, skipping verification."
+         continue
+      fi
+      pushd "${submodule_path_item}" >/dev/null || error "Failed to enter submodule directory '${submodule_path_item}'!"
+      submodule_head="$(git rev-parse HEAD)" || {
+         popd >/dev/null
+         error "Failed to get HEAD commit for submodule '${submodule_path_item}'!"
+      }
+      true "INFO: Verifying submodule '${submodule_path_item}' at commit '${submodule_head}'..."
+      if ! verify_ref "${submodule_head}" 'commit'; then
+         popd >/dev/null
+         error "Verification failed for submodule '${submodule_path_item}'!"
+      fi
+      popd >/dev/null
+   done
+}
+
 git_sanity_test_main() {
    ## Sanity-check; verify the signature of the current ref. If the user has
    ## never verified the repo before, this can be bypassed if the repo is
@@ -214,6 +243,8 @@ git_sanity_test_main() {
 
    git_sanity_test_check_for_untagged_commits
    git_sanity_test_check_for_uncommitted_changes
+
+   git_submodule_verify
 }
 
 if [ "${git_sanity_test_was_sourced}" = 'false' ]; then


### PR DESCRIPTION
## Summary
This PR adds verification of git submodules to the sanity check and update workflows. A new `git_submodule_verify()` function is introduced to validate the integrity of all initialized submodules in the repository.

## Key Changes
- **New `git_submodule_verify()` function**: Iterates through all submodules defined in `.gitmodules`, verifies that they are initialized, and validates the signature of each submodule's HEAD commit using the parent repository's centralized signing policy
- **Integration into `git_sanity_test_main()`**: Added submodule verification as part of the standard git sanity checks
- **Integration into `update_repo()`**: Added submodule verification in two locations:
  - After submodule updates when no specific target ref is provided
  - After submodule updates when a target ref is being checked out

## Implementation Details
- The function gracefully skips uninitialized submodules with an informational message rather than failing
- Uses the parent repository's `openpgp-policy.toml` for all submodule verification, maintaining a centralized signing policy across all repositories
- Properly handles directory navigation with `pushd`/`popd` and includes error handling for failed operations
- Extracts submodule paths from `.gitmodules` using `grep` and `awk`

https://claude.ai/code/session_01KXLzqaVR92tYzqpg6Cpatq